### PR TITLE
Remove matrix of one element from CI workflow

### DIFF
--- a/.github/workflows/update-pot-file.yml
+++ b/.github/workflows/update-pot-file.yml
@@ -9,21 +9,9 @@ jobs:
         # Use containers on their ubuntu latest image
         runs-on: ubuntu-latest
 
-        # Set up the matrix of distributions to test
-        strategy:
-            # only one job at once otherwise one job will push and
-            # second job will get conflict on remote
-            max-parallel: 1
-
-            matrix:
-                container: ["ubuntu:latest"]
-
-        container:
-            image: ${{ matrix.container }}
-
         steps:
             - name: Checkout rpminspect
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   path: rpminspect
                   repository: rpminspect/rpminspect
@@ -41,7 +29,7 @@ jobs:
                   make -C rpminspect update-pot
 
             - name: Checkout rpminspect-l10n
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   path: rpminspect-l10n
                   ref: main


### PR DESCRIPTION
Matrix is only needed when running in several scenarios, like different operating systems. Since it is not the case of this workflow, it can be removed.