### PR TITLE
Fix apt commands

### DIFF
--- a/.github/workflows/update-pot-file.yml
+++ b/.github/workflows/update-pot-file.yml
@@ -59,7 +59,7 @@ jobs:
                       echo "The rpminspect.pot file did not change."
                       exit 0
                   else
-                      git dif --cached
+                      git diff --cached
                   fi
 
                   git commit -m "Update ${{ matrix.branch }} rpminspect.pot file"

--- a/.github/workflows/update-pot-file.yml
+++ b/.github/workflows/update-pot-file.yml
@@ -9,9 +9,21 @@ jobs:
         # Use containers on their ubuntu latest image
         runs-on: ubuntu-latest
 
+        # Set up the matrix of distributions to test
+        strategy:
+            # only one job at once otherwise one job will push and
+            # second job will get conflict on remote
+            max-parallel: 1
+
+            matrix:
+                container: ["ubuntu:latest"]
+
+        container:
+            image: ${{ matrix.container }}
+
         steps:
             - name: Checkout rpminspect
-              uses: actions/checkout@v4
+              uses: actions/checkout@v3
               with:
                   path: rpminspect
                   repository: rpminspect/rpminspect
@@ -29,7 +41,7 @@ jobs:
                   make -C rpminspect update-pot
 
             - name: Checkout rpminspect-l10n
-              uses: actions/checkout@v4
+              uses: actions/checkout@v3
               with:
                   path: rpminspect-l10n
                   ref: main

--- a/.github/workflows/update-pot-file.yml
+++ b/.github/workflows/update-pot-file.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout rpminspect
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   path: rpminspect
                   repository: rpminspect/rpminspect
@@ -41,7 +41,7 @@ jobs:
                   make -C rpminspect update-pot
 
             - name: Checkout rpminspect-l10n
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   path: rpminspect-l10n
                   ref: main


### PR DESCRIPTION
The workflow is failing right now because apt-get commands as they are now won't work outside a container. Prepending sudo won't do the job, as the make command fails to run all statements correctly.

This partially reverts #4, keeping the version bump of the actions/checkout.

@dcantrell 